### PR TITLE
Issue 3 coding standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Added `ext-curl` as dependency to composer.json #1
+
 ## 0.2
 * BREAKING: Removed Transport domain to keep it simple
 * Removed «Suggest» section from composer.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 * Added `ext-curl` as dependency to composer.json #1
+* Updated code formatting to latest inpsyde/php-coding-standard #3
+* BREAKING: Added parameter type hints to `LogzIoHandler::__construct(..., int $level, ...)` and `LogzIoHandler::send(string $data)` according to #3
 
 ## 0.2
 * BREAKING: Removed Transport domain to keep it simple

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Added `ext-curl` as dependency to composer.json #1
 * Updated code formatting to latest inpsyde/php-coding-standard #3
 * BREAKING: Added parameter type hints to `LogzIoHandler::__construct(..., int $level, ...)` and `LogzIoHandler::send(string $data)` according to #3
-
+* Added `Inpsyde\LogzIoMonolog\Exception\Exception` and `Inpsyde\LogzIoMonolog\Exception\DomainException`
 ## 0.2
 * BREAKING: Removed Transport domain to keep it simple
 * Removed «Suggest» section from composer.json

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
   "require": {
     "php": ">=7.0",
     "monolog/monolog": "^1.23",
-    "ext-curl": "*"
+    "ext-curl": "*",
+    "inpsyde/php-coding-standards": "@stable"
   },
   "require-dev": {
     "php": ">=7",
-    "phpunit/phpunit": "6.3.*",
-    "inpsyde/php-coding-standards": "^0.8"
+    "phpunit/phpunit": "6.3.*"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
   ],
   "require": {
     "php": ">=7.0",
-    "monolog/monolog": "^1.23"
+    "monolog/monolog": "^1.23",
+    "ext-curl": "*"
   },
   "require-dev": {
     "php": ">=7",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,5 +1,10 @@
 <?xml version="1.0"?>
 <ruleset name="Inpsyde Logz.io Monolog integration">
     <file>./src</file>
-    <rule ref="Inpsyde"/>
+    <rule ref="Inpsyde">
+        <!-- PHPStorm is right now not able to do reformat this properly -->
+        <exclude name="Inpsyde.CodeQuality.FunctionBodyStart.WrongForMultiLineDeclaration" />
+        <!-- $ch is a common variable name for curl handler resource -->
+        <exclude name="Inpsyde.CodeQuality.ElementNameMinimalLength.TooShort" />
+    </rule>
 </ruleset>

--- a/src/Exception/DomainException.php
+++ b/src/Exception/DomainException.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Inpsyde\LogzIoMonolog\Exception;
+
+class DomainException extends \DomainException implements Exception
+{
+
+}

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Inpsyde\LogzIoMonolog\Exception;
+
+interface Exception extends \Throwable
+{
+
+}

--- a/src/Formatter/LogzIoFormatter.php
+++ b/src/Formatter/LogzIoFormatter.php
@@ -37,9 +37,9 @@ class LogzIoFormatter extends JsonFormatter
      */
     public function format(array $record): string
     {
-        if (isset($record[ "datetime" ]) && ($record[ "datetime" ] instanceof \DateTimeInterface)) {
-            $record[ "@timestamp" ] = $record[ "datetime" ]->format(self::DATETIME_FORMAT);
-            unset($record[ "datetime" ]);
+        if (isset($record["datetime"]) && ($record["datetime"] instanceof \DateTimeInterface)) {
+            $record["@timestamp"] = $record["datetime"]->format(self::DATETIME_FORMAT);
+            unset($record["datetime"]);
         }
 
         return parent::format($record);

--- a/src/Handler/LogzIoHandler.php
+++ b/src/Handler/LogzIoHandler.php
@@ -45,7 +45,7 @@ final class LogzIoHandler extends AbstractProcessingHandler
         string $token,
         string $type = 'http-bulk',
         bool $useSsl = true,
-        $level = Logger::DEBUG,
+        int $level = Logger::DEBUG,
         bool $bubble = true
     ) {
         $this->token = $token;
@@ -68,7 +68,7 @@ final class LogzIoHandler extends AbstractProcessingHandler
         $this->send($record["formatted"]);
     }
 
-    protected function send($data)
+    protected function send(string $data)
     {
         $headers = ['Content-Type: application/json'];
         $ch = curl_init();

--- a/src/Handler/LogzIoHandler.php
+++ b/src/Handler/LogzIoHandler.php
@@ -2,6 +2,7 @@
 
 namespace Inpsyde\LogzIoMonolog\Handler;
 
+use Inpsyde\LogzIoMonolog\Exception\DomainException;
 use Inpsyde\LogzIoMonolog\Formatter\LogzIoFormatter;
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Handler\AbstractProcessingHandler;
@@ -65,6 +66,9 @@ final class LogzIoHandler extends AbstractProcessingHandler
 
     protected function write(array $record)
     {
+        if (! array_key_exists('formatted', $record) || ! is_string($record['formatted'])) {
+            throw new DomainException("The record needs to be formatted as string");
+        }
         $this->send($record["formatted"]);
     }
 

--- a/src/Handler/LogzIoHandler.php
+++ b/src/Handler/LogzIoHandler.php
@@ -47,9 +47,6 @@ final class LogzIoHandler extends AbstractProcessingHandler
         bool $bubble = true
     ) {
 
-        if (! extension_loaded('curl')) {
-            throw new \LogicException('The curl extension is needed to use the LogzIoHandler');
-        }
         $this->token = $token;
         $this->type = $type;
         $this->endpoint = $useSSL

--- a/src/Handler/LogzIoHandler.php
+++ b/src/Handler/LogzIoHandler.php
@@ -21,10 +21,12 @@ final class LogzIoHandler extends AbstractProcessingHandler
      * @var string
      */
     private $token;
+
     /**
      * @var string
      */
     private $type;
+
     /**
      * @var string
      */
@@ -33,7 +35,7 @@ final class LogzIoHandler extends AbstractProcessingHandler
     /**
      * @param string $token Log token supplied by Logz.io.
      * @param string $type Host name supplied by Logz.io.
-     * @param bool $useSSL Whether or not SSL encryption should be used.
+     * @param bool $useSsl Whether or not SSL encryption should be used.
      * @param int|string $level The minimum logging level to trigger this handler.
      * @param bool $bubble Whether or not messages that are handled should bubble up the stack.
      *
@@ -42,35 +44,32 @@ final class LogzIoHandler extends AbstractProcessingHandler
     public function __construct(
         string $token,
         string $type = 'http-bulk',
-        bool $useSSL = true,
+        bool $useSsl = true,
         $level = Logger::DEBUG,
         bool $bubble = true
     ) {
-
         $this->token = $token;
         $this->type = $type;
-        $this->endpoint = $useSSL
+        $this->endpoint = $useSsl
             ? 'https://listener.logz.io:8071/'
             : 'http://listener.logz.io:8070/';
         $this->endpoint .= '?'.http_build_query(
-                [
-                    'token' => $this->token,
-                    'type' => $this->type,
-                ]
-            );
+            [
+                'token' => $this->token,
+                'type' => $this->type,
+            ]
+        );
 
         parent::__construct($level, $bubble);
     }
 
     protected function write(array $record)
     {
-
         $this->send($record["formatted"]);
     }
 
     protected function send($data)
     {
-
         $headers = ['Content-Type: application/json'];
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $this->endpoint);
@@ -84,12 +83,10 @@ final class LogzIoHandler extends AbstractProcessingHandler
 
     public function handleBatch(array $records)
     {
-
         $level = $this->level;
         $records = array_filter(
             $records,
             function (array $record) use ($level): bool {
-
                 return ($record['level'] >= $level);
             }
         );
@@ -108,7 +105,6 @@ final class LogzIoHandler extends AbstractProcessingHandler
     // phpcs:disable InpsydeCodingStandard.CodeQuality.NoAccessors.NoGetter
     protected function getDefaultFormatter(): FormatterInterface
     {
-
         return new LogzIoFormatter();
     }
 }


### PR DESCRIPTION
Changes:
* Updated code formatting to latest inpsyde/php-coding-standard #3
* BREAKING: Added parameter type hints to `LogzIoHandler::__construct(..., int $level, ...)` and `LogzIoHandler::send(string $data)` according to #3
