### PR TITLE
Make LogzioHandler work with monolog 2 too

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     }
   ],
   "require": {
-    "php": "^7.0",
+    "php": "^7.1",
     "ext-curl": "*",
-    "monolog/monolog": "^1.23"
+    "monolog/monolog": "^1.23|^2.0"
   },
   "require-dev": {
     "ext-json": "*",    

--- a/src/Handler/LogzIoHandler.php
+++ b/src/Handler/LogzIoHandler.php
@@ -16,8 +16,8 @@ use Monolog\Logger;
  */
 final class LogzIoHandler extends AbstractProcessingHandler
 {
-    const HOST_EU = 'listener-eu.logz.io';
-    const HOST_US = 'listener.logz.io';
+    public const HOST_EU = 'listener-eu.logz.io';
+    public const HOST_US = 'listener.logz.io';
 
     /**
      * @var string
@@ -64,13 +64,13 @@ final class LogzIoHandler extends AbstractProcessingHandler
         parent::__construct($level, $bubble);
     }
 
-    protected function write(array $record)
+    protected function write(array $record): void
     {
         $this->send($record['formatted']);
     }
 
     // phpcs:disable Inpsyde.CodeQuality.ArgumentTypeDeclaration.NoArgumentType
-    protected function send($data)
+    protected function send($data): void
     {
         $handle = curl_init();
 
@@ -83,7 +83,7 @@ final class LogzIoHandler extends AbstractProcessingHandler
         Util::execute($handle);
     }
 
-    public function handleBatch(array $records)
+    public function handleBatch(array $records): void
     {
         $level = $this->level;
         $records = array_filter(


### PR DESCRIPTION
In order to make this package work with monolog 2, I had to declare the void return types on inherited methods, which requires php 7.1. So this would mean a major version upgrade if the PR is accepted and you follow semver.

Other than that, no changes were needed. I've tested it and found the logs in logz.io.