### PR TITLE
Increase resolution of log timestamps

### DIFF
--- a/src/Formatter/LogzIoFormatter.php
+++ b/src/Formatter/LogzIoFormatter.php
@@ -11,10 +11,7 @@ use Monolog\Formatter\JsonFormatter;
  */
 class LogzIoFormatter extends JsonFormatter
 {
-    /**
-     * yyyy-MM-dd'T'HH:mm:ss.SSSZ
-     */
-    const DATETIME_FORMAT = 'c';
+    const DATETIME_FORMAT = \DateTimeInterface::RFC3339_EXTENDED;
 
     /**
      * Overrides the default batch mode to new lines for compatibility with the Logz.io bulk API.


### PR DESCRIPTION
The 'c' format does not include milliseconds. This causes logs sent within the same second to sometimes appear out of order.

Change to use the `\DateTimeInterface::RFC3339_EXTENDED` constant which includes milliseconds.

After testing, I found that Logz.io truncates timestamps containing microseconds. There is no need to be that fine-grained.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds milliseconds to the `@timestamp` field sent to Logz.io.

**What is the current behavior?** (You can also link to an open issue here)
The `@timestamp` field only goes down to the seconds resolution.


**What is the new behavior (if this is a feature change)?**
Logs sent to Logz.io now have milliseconds, making them higher resolution and less likely to be out of order.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking change. This only works on PHP 7.2.0+, but that is already embedded in the `composer.json`.


**Other information**:
