### PR TITLE
Allow install on PHP >=8 environments

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -1,0 +1,20 @@
+name: Quality assurance
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'composer.json'
+      - '**.php'
+  push:
+    paths:
+      - 'composer.json'
+      - '**.php'
+jobs:
+  static-code-analysis-backend:
+    uses: inpsyde/reusable-workflows/.github/workflows/coding-standards-php.yml@main
+  php-unit-tests:
+    needs: static-code-analysis-backend
+    uses: inpsyde/reusable-workflows/.github/workflows/tests-unit-php.yml@main
+    with:
+      PHP_MATRIX: >-
+        ["7.4", "8.0", "8.1"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.phar
 /vendor/
+/tmp
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require-dev": {
     "ext-json": "*",    
     "phpunit/phpunit": "^6.3",
-    "inpsyde/php-coding-standards": "^0.13"
+    "inpsyde/php-coding-standards": "^1"
   },
   "autoload": {
     "psr-4": {
@@ -34,6 +34,11 @@
   "autoload-dev": {
     "psr-4": {
       "Inpsyde\\LogzIoMonolog\\Tests\\": "tests/"
+    }
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     }
   ],
   "require": {
-    "php": "^7.0",
+    "php": ">=7.0",
     "ext-curl": "*",
     "monolog/monolog": "^1.23"
   },
   "require-dev": {
-    "ext-json": "*",    
-    "phpunit/phpunit": "^6.3",
+    "ext-json": "*",
+    "phpunit/phpunit": "^6.3|^8",
     "inpsyde/php-coding-standards": "^1"
   },
   "autoload": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
 <ruleset name="Inpsyde Logz.io Monolog integration">
     <file>./src</file>
-    <rule ref="Inpsyde"/>
+    <rule ref="Inpsyde">
+        <exclude name="Inpsyde.CodeQuality.ConstantVisibility.NotFound" />
+        <exclude name="Inpsyde.CodeQuality.NoAccessors.NoGetter" />
+        <exclude name="Inpsyde.CodeQuality.LineLength.TooLong" />
+    </rule>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,7 +13,7 @@
 	stopOnFailure="false">
 	<testsuites>
 		<testsuite name="Unit">
-			<directory suffix="Test.php">tests/phpunit/Unit</directory>
+			<directory suffix="Test.php">tests/Unit</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/src/Formatter/LogzIoFormatter.php
+++ b/src/Formatter/LogzIoFormatter.php
@@ -1,4 +1,6 @@
-<?php declare( strict_types=1 );
+<?php
+
+declare(strict_types=1);
 
 namespace Inpsyde\LogzIoMonolog\Formatter;
 

--- a/src/Handler/LogzIoHandler.php
+++ b/src/Handler/LogzIoHandler.php
@@ -1,4 +1,6 @@
-<?php declare( strict_types=1 );
+<?php
+
+declare(strict_types=1);
 
 namespace Inpsyde\LogzIoMonolog\Handler;
 
@@ -54,7 +56,7 @@ final class LogzIoHandler extends AbstractProcessingHandler
         $this->token = $token;
         $this->type = $type;
         $this->endpoint = $ssl ? 'https://' . $host . ':8071/' : 'http://' . $host . ':8070/';
-        $this->endpoint .= '?'.http_build_query(
+        $this->endpoint .= '?' . http_build_query(
             [
                 'token' => $this->token,
                 'type' => $this->type,
@@ -88,7 +90,7 @@ final class LogzIoHandler extends AbstractProcessingHandler
         $level = $this->level;
         $records = array_filter(
             $records,
-            function (array $record) use ($level): bool {
+            static function (array $record) use ($level): bool {
 
                 return ($record['level'] >= $level);
             }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,7 +3,7 @@
 putenv( 'TESTS_PATH=' . __DIR__ );
 putenv( 'LIBRARY_PATH=' . dirname( __DIR__ ) );
 
-$vendor = dirname( dirname( dirname( __FILE__ ) ) ) . '/vendor/';
+$vendor = dirname(__DIR__) . '/vendor/';
 
 if ( ! realpath( $vendor ) ) {
 	die( 'Please install via Composer before running tests.' );


### PR DESCRIPTION
The PHPUnit setup had some invalid paths that needed to be fixed. Also updated dev dependencies. Unittests run on 7.4 and 8.1 environment locally.