### PR TITLE
Implement support for monolog version 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=8.1",
         "ext-curl": "*",
-        "monolog/monolog": "^2.0"
+        "monolog/monolog": ">=3.0"
     },
     "require-dev": {
         "ext-json": "*",

--- a/src/Enum/Host.php
+++ b/src/Enum/Host.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Inpsyde\LogzIoMonolog\Enum;
+
+enum Host: string
+{
+    case UsEast1 = 'listener.logz.io';
+    case ApSoutheast1 = 'listener-au.logz.io';
+    case CaCentral1 = 'listener-ca.logz.io';
+    case EuCentral1 = 'listener-eu.logz.io';
+    case WestEurope = 'listener-nl.logz.io';
+    case EuWest2 = 'listener-uk.logz.io';
+    case WestUs1 = 'listener-wa.logz.io';
+}

--- a/src/Enum/Type.php
+++ b/src/Enum/Type.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Inpsyde\LogzIoMonolog\Enum;
-
-enum Type: string
-{
-    case HttpBulk = 'http_bulk';
-}

--- a/src/Enum/Type.php
+++ b/src/Enum/Type.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Inpsyde\LogzIoMonolog\Enum;
+
+enum Type: string
+{
+    case HttpBulk = 'http_bulk';
+}

--- a/src/Formatter/LogzIoFormatter.php
+++ b/src/Formatter/LogzIoFormatter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Inpsyde\LogzIoMonolog\Formatter;
 
 use Monolog\Formatter\JsonFormatter;
+use Monolog\LogRecord;
 
 /**
  * Encodes message information into JSON in a format compatible with Logz.io.
@@ -32,29 +33,28 @@ class LogzIoFormatter extends JsonFormatter
     /**
      * Appends the '@timestamp' parameter for Logz.io.
      *
-     * @param array $record
-     *
-     * @return string
      * @see \Monolog\Formatter\JsonFormatter::format()
-     *
-     * @link https://support.logz.io/hc/en-us/articles/210206885
+     * @see https://support.logz.io/hc/en-us/articles/210206885
      */
-    public function format(array $record): string
+    public function normalizeRecord(LogRecord $record): array
     {
-        if (isset($record['datetime']) && ($record['datetime'] instanceof \DateTimeInterface)) {
-            $record['@timestamp'] = $record['datetime']->format(self::DATETIME_FORMAT);
-            unset($record['datetime']);
+        $recordData = parent::normalizeRecord($record);
+
+        if (isset($recordData['datetime'])) {
+            $recordData['@timestamp'] = (new \DateTimeImmutable($recordData['datetime']))->format(self::DATETIME_FORMAT);
+
+            unset($recordData['datetime']);
         }
 
         // Logz.io does not allow [null] or [""] as context/extra.
-        if (isset($record['context'])) {
-            $record['context'] = array_filter((array) $record['context']);
+        if (isset($recordData['context'])) {
+            $recordData['context'] = array_filter((array) $recordData['context']);
         }
 
-        if (isset($record['extra'])) {
-            $record['extra'] = array_filter((array) $record['extra']);
+        if (isset($recordData['extra'])) {
+            $recordData['extra'] = array_filter((array) $recordData['extra']);
         }
 
-        return parent::format($record);
+        return $recordData;
     }
 }

--- a/src/Handler/LogzIoHandler.php
+++ b/src/Handler/LogzIoHandler.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Inpsyde\LogzIoMonolog\Handler;
 
+use Inpsyde\LogzIoMonolog\Enum\Host;
+use Inpsyde\LogzIoMonolog\Enum\Type;
 use Inpsyde\LogzIoMonolog\Formatter\LogzIoFormatter;
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Handler\Curl\Util;
-use Monolog\Logger;
+use Monolog\Level;
+use Monolog\LogRecord;
 
 /**
  * @author Christian Brückner <chris@chrico.info>
@@ -18,60 +21,38 @@ use Monolog\Logger;
  */
 final class LogzIoHandler extends AbstractProcessingHandler
 {
-    public const HOST_EU = 'listener-eu.logz.io';
-    public const HOST_US = 'listener.logz.io';
-
-    /**
-     * @var string
-     */
-    private $token;
-
-    /**
-     * @var string
-     */
-    private $type;
-
-    /**
-     * @var string
-     */
-    private $endpoint;
-
     /**
      * @param string $token Log token supplied by Logz.io.
-     * @param string $type Your log type - it helps classify the logs you send.
-     * @param bool $ssl Whether or not SSL encryption should be used.
-     * @param int|string $level The minimum logging level to trigger this handler.
-     * @param bool $bubble Whether or not messages that are handled should bubble up the stack.
-     * @param string $host One of existing listener hosts, by default 'listener.logz.io'
+     * @param Type $type Your log type - it helps classify the logs you send.
+     * @param bool $ssl Whether SSL encryption should be used.
+     * @param Level $level The minimum logging level to trigger this handler.
+     * @param bool $bubble Whether messages that are handled should bubble up the stack.
+     * @param Host $host One of existing listener hosts, by default 'listener.logz.io'
      *
      * @throws \LogicException If curl extension is not available.
      */
     public function __construct(
-        string $token,
-        string $type = 'http-bulk',
+        protected readonly string $token,
+        Type $type = Type::HttpBulk,
         bool $ssl = true,
-        int $level = Logger::DEBUG,
+        Level $level = Level::Debug,
         bool $bubble = true,
-        string $host = self::HOST_US
+        Host $host = Host::UsEast1
     ) {
-
-        $this->token = $token;
-        $this->type = $type;
-
         $queryArgs = [
             'token' => $this->token,
-            'type' => $this->type,
+            'type' => $type->value,
         ];
 
         $this->endpoint = $ssl
-            ? 'https://' . $host . ':8071/'
-            : 'http://' . $host . ':8070/';
+            ? 'https://' . $host->value . ':8071/'
+            : 'http://' . $host->value . ':8070/';
         $this->endpoint .= '?' . http_build_query($queryArgs);
 
         parent::__construct($level, $bubble);
     }
 
-    protected function write(array $record): void
+    protected function write(LogRecord $record): void
     {
         $this->send($record['formatted']);
     }
@@ -95,8 +76,8 @@ final class LogzIoHandler extends AbstractProcessingHandler
         $level = $this->level;
         $records = array_filter(
             $records,
-            static function (array $record) use ($level): bool {
-                return ($record['level'] >= $level);
+            static function (LogRecord $record) use ($level): bool {
+                return ($record->level >= $level);
             }
         );
 

--- a/src/Handler/LogzIoHandler.php
+++ b/src/Handler/LogzIoHandler.php
@@ -21,9 +21,11 @@ use Monolog\LogRecord;
  */
 final class LogzIoHandler extends AbstractProcessingHandler
 {
+    private string $endpoint;
+
     /**
      * @param string $token Log token supplied by Logz.io.
-     * @param Type $type Your log type - it helps classify the logs you send.
+     * @param string $type Your log type - it helps classify the logs you send.
      * @param bool $ssl Whether SSL encryption should be used.
      * @param Level $level The minimum logging level to trigger this handler.
      * @param bool $bubble Whether messages that are handled should bubble up the stack.
@@ -33,7 +35,7 @@ final class LogzIoHandler extends AbstractProcessingHandler
      */
     public function __construct(
         protected readonly string $token,
-        Type $type = Type::HttpBulk,
+        string $type = 'http-bulk',
         bool $ssl = true,
         Level $level = Level::Debug,
         bool $bubble = true,
@@ -41,7 +43,7 @@ final class LogzIoHandler extends AbstractProcessingHandler
     ) {
         $queryArgs = [
             'token' => $this->token,
-            'type' => $type->value,
+            'type' => $type,
         ];
 
         $this->endpoint = $ssl

--- a/tests/Unit/Formatter/LogzIoFormatterTest.php
+++ b/tests/Unit/Formatter/LogzIoFormatterTest.php
@@ -4,7 +4,8 @@ namespace Inpsyde\LogzIoMonolog\Tests\Unit\Formatter;
 
 use Inpsyde\LogzIoMonolog\Formatter\LogzIoFormatter;
 use Monolog\Formatter\JsonFormatter;
-use Monolog\Logger;
+use Monolog\Level;
+use Monolog\LogRecord;
 use PHPUnit\Framework\TestCase;
 
 class LogzIoFormatterTest extends TestCase
@@ -27,25 +28,25 @@ class LogzIoFormatterTest extends TestCase
     {
         $formatter         = new LogzIoFormatter();
         $record            = $this->getRecord();
-        $formatted_decoded = json_decode($formatter->format($record), true);
+        $normalizedRecord  = $formatter->normalizeRecord($record);
 
-        static::assertArrayNotHasKey('datetime', $formatted_decoded);
-        static::assertArrayHasKey('@timestamp', $formatted_decoded);
+        static::assertArrayNotHasKey('datetime', $normalizedRecord);
+        static::assertArrayHasKey('@timestamp', $normalizedRecord);
     }
 
     /**
-     * @return array Record
+     * @return LogRecord
      */
-    protected function getRecord($level = Logger::WARNING, $message = 'test', $context = array())
+    protected function getRecord($level = Level::Warning, $message = 'test', $context = array())
     {
-        return array(
-            'message'    => $message,
-            'context'    => $context,
-            'level'      => $level,
-            'level_name' => Logger::getLevelName($level),
-            'channel'    => 'test',
-            'datetime'   => \DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true))),
-            'extra'      => array(),
+        return new LogRecord(
+            \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', microtime(true))),
+            'test',
+            $level,
+            $message,
+            $context,
+            [],
+            null
         );
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Support for monolog 3 (BC)


**What is the current behavior?** (You can also link to an open issue here)
The current package only supports monolog version 2


**What is the new behavior (if this is a feature change)?**
Package supports monolog version 3, this also bumps the minimal PHP version to >= 8.1

I also added two enums, one with all the regions and one for the type. I did not add all the types (yet), could to that if you want me to.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes, minimal PHP version needs to be 8.1


**Other information**:
The reason I updated the package is that I want to use it in a Symfony 6.2 project which installs monolog v3. 