### PR TITLE
Fix level comparison when filtering records

### DIFF
--- a/src/Handler/LogzIoHandler.php
+++ b/src/Handler/LogzIoHandler.php
@@ -79,7 +79,7 @@ final class LogzIoHandler extends AbstractProcessingHandler
         $records = array_filter(
             $records,
             static function (LogRecord $record) use ($level): bool {
-                return ($record->level >= $level);
+                return $level->includes($record->level);
             }
         );
 

--- a/src/Handler/LogzIoHandler.php
+++ b/src/Handler/LogzIoHandler.php
@@ -79,7 +79,12 @@ final class LogzIoHandler extends AbstractProcessingHandler
         $records = array_filter(
             $records,
             static function (LogRecord $record) use ($level): bool {
-                return $level->includes($record->level);
+                if (method_exists($level, 'includes')) {
+                    return $level->includes($record->level);
+                }
+                else {
+                    return ($record->level >= $level);
+                }
             }
         );
 


### PR DESCRIPTION
At least on PHP 8.2.18 with Monolog 3.7.0 the comparison of the `\Monolog\Level` enums using `>=` evaluates to false when the  record level is anything other than exactly the level specified rather than comparing the integer value of the Enum.

The solution is to use `\Monolog\Level::includes()` https://github.com/Seldaek/monolog/blob/main/src/Monolog/Level.php#L111-L117 to handle the comparison operation rather than `>=`.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] ~Tests for the changes have been added (for bug fixes/features)~ _Not possible without significant rewrites to the Handler code to separate filtering from sending._
- [ ] ~Docs have been added/updated (for bug fixes/features)~ _There seems to be no changelog to update._


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

**What is the current behavior?** (You can also link to an open issue here)

Currently (at least on PHP 8.2.18 with Monolog 3.7.0) only logs that are precisely the Level configured are sent, not logs that are at that level or greater.

**What is the new behavior (if this is a feature change)?**

Logs of the level configured or greater are now sent.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.