### PR TITLE
Add curl timeout limit for remote request

### DIFF
--- a/src/Handler/LogzIoHandler.php
+++ b/src/Handler/LogzIoHandler.php
@@ -69,7 +69,6 @@ final class LogzIoHandler extends AbstractProcessingHandler
         curl_setopt($handle, CURLOPT_POSTFIELDS, $data);
         curl_setopt($handle, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
         curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($handle, CURLOPT_CONNECTTIMEOUT, 2);
         curl_setopt($handle, CURLOPT_TIMEOUT, 5);
 
         Util::execute($handle);

--- a/src/Handler/LogzIoHandler.php
+++ b/src/Handler/LogzIoHandler.php
@@ -69,6 +69,8 @@ final class LogzIoHandler extends AbstractProcessingHandler
         curl_setopt($handle, CURLOPT_POSTFIELDS, $data);
         curl_setopt($handle, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
         curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($handle, CURLOPT_CONNECTTIMEOUT, 2);
+        curl_setopt($handle, CURLOPT_TIMEOUT, 5);
 
         Util::execute($handle);
     }


### PR DESCRIPTION
This PR adds a timeout to cURL requests sent to `logz.io` to prevent potential hangs when the logging service is slow or unresponsive.

**Details**
- Introduced a reasonable timeout for `logz.io` HTTP requests.
- Ensures that failed or long-running logging calls do not block the main PHP process.
- No functional changes expected.

**Why?**
Previously, `logz.io` requests had no timeout, which could cause performance degradation in rare cases when the remote endpoint was unavailable.