### PR TITLE
Include milliseconds to the date-time format

### DIFF
--- a/src/Formatter/LogzIoFormatter.php
+++ b/src/Formatter/LogzIoFormatter.php
@@ -17,7 +17,7 @@ class LogzIoFormatter extends JsonFormatter
     /**
      * yyyy-MM-dd'T'HH:mm:ss.SSSZ
      */
-    public const DATETIME_FORMAT = 'c';
+    public const DATETIME_FORMAT = 'Y-m-d\TH:i:s.vP';
 
     /**
      * Overrides the default batch mode to new lines for compatibility with the Logz.io bulk API.


### PR DESCRIPTION
This PR updates the `DATETIME_FORMAT` in `LogzIoFormatter` to include milliseconds. This resolves an issue where multiple log entries appear to overlap because they occur within the same second.

Although the existing comment states that the date-time format includes milliseconds, the current implementation uses the `c` format, which does not include millisecond precision.

https://github.com/inpsyde/logzio-monolog/blob/f44d97419bc56d688143509d26bb19e1ee3db03c/src/Formatter/LogzIoFormatter.php#L17-L20